### PR TITLE
Exposing fortran_order in LoadArrayFromNumpy

### DIFF
--- a/npy.hpp
+++ b/npy.hpp
@@ -395,14 +395,14 @@ inline void write_header(std::ostream& out, const std::string& descr, bool fortr
     // write header length
     if (version[0] == 1 && version[1] == 0) {
       char header_len_le16[2];
-      uint16_t header_len = header_dict.length() + padding.length() + 1;
+      uint16_t header_len = static_cast<uint16_t>(header_dict.length() + padding.length() + 1);
 
       header_len_le16[0] = (header_len >> 0) & 0xff;
       header_len_le16[1] = (header_len >> 8) & 0xff;
       out.write(reinterpret_cast<char *>(header_len_le16), 2);
     }else{
       char header_len_le32[4];
-      uint32_t header_len = header_dict.length() + padding.length() + 1;
+      uint32_t header_len = static_cast<uint32_t>(header_dict.length() + padding.length() + 1);
 
       header_len_le32[0] = (header_len >> 0) & 0xff;
       header_len_le32[1] = (header_len >> 8) & 0xff;
@@ -482,6 +482,13 @@ inline void SaveArrayAsNumpy( const std::string& filename, bool fortran_order, u
 template<typename Scalar>
 inline void LoadArrayFromNumpy(const std::string& filename, std::vector<unsigned long>& shape, std::vector<Scalar>& data)
 {
+    bool fortran_order;
+    LoadArrayFromNumpy<Scalar>(filename, shape, fortran_order, data);
+}
+
+template<typename Scalar>
+inline void LoadArrayFromNumpy(const std::string& filename, std::vector<unsigned long>& shape, bool& fortran_order, std::vector<Scalar>& data)
+{
     std::ifstream stream(filename, std::ifstream::binary);
     if(!stream) {
         throw std::runtime_error("io error: failed to open a file.");
@@ -490,7 +497,6 @@ inline void LoadArrayFromNumpy(const std::string& filename, std::vector<unsigned
     std::string header = read_header(stream);
 
     // parse header
-    bool fortran_order;
     std::string typestr;
 
     parse_header(header, typestr, fortran_order, shape);

--- a/tests/createnpy.py
+++ b/tests/createnpy.py
@@ -1,6 +1,10 @@
 #!/usr/bin/python3
 
 import numpy
+import os
+
+if not os.path.isdir("data"):
+    os.mkdir("data")
 
 data = [ [1, 2, 3], [4, 5, 6], ]
 
@@ -12,6 +16,7 @@ dtypes = ['f4', 'f8',
 for d in dtypes:
   a = numpy.array(data, numpy.dtype(d))
   numpy.save('data/' + d + ".npy", a)
+  numpy.save('data/' + d + "_t.npy", a.T)
 
 booldata = [ [False, True, False], [True, False, True], ]
 a = numpy.array(booldata, numpy.dtype(bool))

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -7,18 +7,25 @@ using namespace std;
 
 int test_load(void) {
   vector<unsigned long> shape;
+  bool fortran_order;
   vector<double> data;
 
-  npy::LoadArrayFromNumpy("data/f8.npy", shape, data);
+  for (auto path : {"data/f8.npy", "data/f8_t.npy"}) {
+    shape.clear();
+    data.clear();
+    npy::LoadArrayFromNumpy(path, shape, fortran_order, data);
 
-  cout << "shape: ";
-  for (size_t i = 0; i<shape.size(); i++)
-    cout << shape[i] << ", ";
-  cout << endl;
-  cout << "data: ";
-  for (size_t i = 0; i<data.size(); i++)
-    cout << data[i] << ", ";
-  cout << endl;
+    cout << "shape: ";
+    for (size_t i = 0; i<shape.size(); i++)
+      cout << shape[i] << ", ";
+    cout << endl;
+    cout << "fortran order: " << (fortran_order ? "+" : "-");
+    cout << endl;
+    cout << "data: ";
+    for (size_t i = 0; i<data.size(); i++)
+      cout << data[i] << ", ";
+    cout << endl << endl;
+  }
 
   return 0;
 }


### PR DESCRIPTION
I've exposed "fortran_order" in LoadArrayFromNumpy because (as shown in added examples created by createnpy.py) transposing the matrix in numpy only changes that attribute by default and the layout of the matrix data after the header stays the same as without trasposition. Having fortran_order is therefore crucial for interpreting the data. Not wanting to break the interface I added overloaded function.
Also silenced a casting warning.
