### PR TITLE
Add missing <array> include

### DIFF
--- a/npy.hpp
+++ b/npy.hpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <cstdint>
 #include <cstring>
+#include <array>
 #include <vector>
 #include <stdexcept>
 #include <algorithm>


### PR DESCRIPTION
Hello! This is a nifty library, thanks for sharing it.
I had compilation fail on Android (libc++) due to a missing `#include <array>` :)
Cheers!