### PR TITLE
Add signed char to acceptable Scalar type

### DIFF
--- a/npy.hpp
+++ b/npy.hpp
@@ -147,6 +147,11 @@ template<> struct has_typestring<char>{
   static constexpr dtype_t dtype = {no_endian_char, 'i', sizeof(char)};
 };
 constexpr dtype_t has_typestring<char>::dtype;
+template<> struct has_typestring<signed char>{ 
+  static const bool value=true;
+  static constexpr dtype_t dtype = {no_endian_char, 'i', sizeof(signed char)};
+};
+constexpr dtype_t has_typestring<signed char>::dtype;
 template<> struct has_typestring<short>{ 
   static const bool value=true;
   static constexpr dtype_t dtype = {host_endian_char, 'i', sizeof(short)};


### PR DESCRIPTION
In C++, the signedness of `char` is platform dependent.

FIY: [Fundamental types - cppreference.com](https://en.cppreference.com/w/cpp/language/types)

> The signedness of `char` depends on the compiler and the target platform: the defaults for ARM and PowerPC are typically unsigned, the defaults for x86 and x64 are typically signed.

It is better to use `signed char` instead of `char` in signedness-aware coding.