### PR TITLE
Cumulative improvements

### DIFF
--- a/include/npy.hpp
+++ b/include/npy.hpp
@@ -445,7 +445,7 @@ inline std::vector <std::string> parse_tuple(std::string in) {
 template<typename T>
 inline std::string write_tuple(const std::vector <T> &v) {
   if (v.size() == 0)
-    return "";
+    return "()";
 
   std::ostringstream ss;
 
@@ -515,8 +515,6 @@ inline header_t parse_header(std::string header) {
 
   // parse the shape tuple
   auto shape_v = npy::pyparse::parse_tuple(shape_s);
-  if (shape_v.size() == 0)
-    throw std::runtime_error("invalid shape tuple in header");
 
   std::vector <ndarray_len_t> shape;
   for (auto item : shape_v) {

--- a/include/npy.hpp
+++ b/include/npy.hpp
@@ -620,7 +620,7 @@ inline ndarray_len_t comp_size(const std::vector <ndarray_len_t> &shape) {
 template<typename Scalar>
 inline void
 SaveArrayAsNumpy(const std::string &filename, bool fortran_order, unsigned int n_dims, const unsigned long shape[],
-                 const std::vector <Scalar> &data) {
+                 const Scalar* data) {
   static_assert(has_typestring<Scalar>::value, "scalar type not understood");
   dtype_t dtype = has_typestring<Scalar>::dtype;
 
@@ -635,9 +635,15 @@ SaveArrayAsNumpy(const std::string &filename, bool fortran_order, unsigned int n
 
   auto size = static_cast<size_t>(comp_size(shape_v));
 
-  stream.write(reinterpret_cast<const char *>(data.data()), sizeof(Scalar) * size);
+  stream.write(reinterpret_cast<const char *>(data), sizeof(Scalar) * size);
 }
 
+template<typename Scalar>
+inline void
+SaveArrayAsNumpy(const std::string &filename, bool fortran_order, unsigned int n_dims, const unsigned long shape[],
+                 const std::vector <Scalar> &data) {
+  SaveArrayAsNumpy(filename, fortran_order, n_dims, shape, data.data());
+}
 
 template<typename Scalar>
 inline void

--- a/include/npy.hpp
+++ b/include/npy.hpp
@@ -88,7 +88,7 @@ struct dtype_t {
   inline std::string str() const {
     const size_t max_buflen = 16;
     char buf[max_buflen];
-    std::sprintf(buf, "%c%c%u", byteorder, kind, itemsize);
+    std::snprintf(buf, max_buflen, "%c%c%u", byteorder, kind, itemsize);
     return std::string(buf);
   }
 

--- a/tests/createnpy.py
+++ b/tests/createnpy.py
@@ -6,7 +6,11 @@ import os
 if not os.path.isdir("data"):
     os.mkdir("data")
 
-data = [ [1, 2, 3], [4, 5, 6], ]
+data_categories = {
+  "matrix": [ [1, 2, 3], [4, 5, 6], ],
+  "empty":  [ [], [], ],
+  "scalar": 42,
+}
 
 dtypes = ['f4', 'f8', 
           'i1', 'i2', 'i4', 'i8',
@@ -14,9 +18,10 @@ dtypes = ['f4', 'f8',
           'c8', 'c16', ]
 
 for d in dtypes:
-  a = numpy.array(data, numpy.dtype(d))
-  numpy.save('data/' + d + ".npy", a)
-  numpy.save('data/' + d + "_t.npy", a.T)
+  for data_name, data in data_categories.items():
+    a = numpy.array(data, numpy.dtype(d))
+    numpy.save(f"data/{data_name}_{d}.npy", a)
+    numpy.save(f"data/{data_name}_{d}_t.npy", a.T)
 
 booldata = [ [False, True, False], [True, False, True], ]
 a = numpy.array(booldata, numpy.dtype(bool))

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -10,7 +11,16 @@ int test_load(void) {
   bool fortran_order;
   vector<double> data;
 
-  for (auto path : {"data/f8.npy", "data/f8_t.npy"}) {
+  vector<const char*> allpaths {
+    "data/matrix_f8.npy",
+    "data/matrix_f8_t.npy",
+    "data/empty_f8.npy",
+    "data/empty_f8_t.npy",
+    "data/scalar_f8.npy",
+    "data/scalar_f8_t.npy",
+  };
+
+  for (auto path : allpaths) {
     shape.clear();
     data.clear();
     npy::LoadArrayFromNumpy(path, shape, fortran_order, data);
@@ -31,12 +41,24 @@ int test_load(void) {
 }
 
 int test_save(void) {
-  const long unsigned leshape [] = {2,3};
-  vector<double> data {1, 2, 3, 4, 5, 6};
-  npy::SaveArrayAsNumpy("data/out.npy", false, 2, leshape, data);
+  const vector<double> data1 {1, 2, 3, 4, 5, 6};
+  array<long unsigned, 2> leshape11 {{2,3}};
+  array<long unsigned, 1> leshape12 {{6}};
 
-  const long unsigned leshape2 [] = {6};
-  npy::SaveArrayAsNumpy("data/out2.npy", false, 1, leshape2, data);
+  const double data2[] = {7};
+  array<long unsigned, 3> leshape21 {{1,1,1}};
+  array<long unsigned, 0> leshape22 {};
+
+  const array<double, 0> data3;
+  array<long unsigned, 2> leshape31 {{4,0}};
+
+  npy::SaveArrayAsNumpy("data/out11.npy", false, leshape11.size(), leshape11.data(), data1);
+  npy::SaveArrayAsNumpy("data/out12.npy", false, leshape12.size(), leshape12.data(), data1);
+
+  npy::SaveArrayAsNumpy("data/out21.npy", false, leshape21.size(), leshape21.data(), data2);
+  npy::SaveArrayAsNumpy("data/out22.npy", false, leshape22.size(), leshape22.data(), data2);
+
+  npy::SaveArrayAsNumpy("data/out31.npy", false, leshape31.size(), leshape31.data(), data3.data());
 
   return 0;
 }


### PR DESCRIPTION
Thanks for making this library! When I'm trying to use it, I found some room for improvement so I changed the codes in the following aspects. I really hope you can help review it. Thanks!

1. Changed `sprintf` into `snprintf` because the latter is a safer function.
2. Supported numpy scalars as 0-dimensional arrays. Test cases are expanded to include these cases.
3. Add an interface such that `SaveArrayAsNumpy` can work with raw pointer buffer, which is very useful if the user is using a contiguous container other than `std::vector`, such as `Eigen::Matrix` or `std::array`.