### PR TITLE
fix asan container overflow

### DIFF
--- a/include/npy.hpp
+++ b/include/npy.hpp
@@ -472,8 +472,7 @@ inline std::string read_header(std::istream &istream) {
     throw std::runtime_error("unsupported file format version");
   }
 
-  auto buf_v = std::vector<char>();
-  buf_v.reserve(header_length);
+  auto buf_v = std::vector<char>(header_length);
   istream.read(buf_v.data(), header_length);
   std::string header(buf_v.data(), header_length);
 


### PR DESCRIPTION
Hi,

Using the lib I spotted an ASAN issue du to:
l.476
```
  auto buf_v = std::vector<char>();
  buf_v.reserve(header_length);
  istream.read(buf_v.data(), header_length);
```
it seems that reserve not changing the size of the vector and using istream read on the buffer (which does not change the size again)
lead to a container overflow later on.

The proper way would be to use a resize or simply declare the vector with the correct size:
```
  auto buf_v = std::vector<char>(header_length);
  istream.read(buf_v.data(), header_length);
```
This get rid of the issue.

Cheers,
Matt