### PR TITLE
Moved declaration of short LoadArrayFromNumpy after the original

### DIFF
--- a/include/npy.hpp
+++ b/include/npy.hpp
@@ -516,13 +516,6 @@ SaveArrayAsNumpy(const std::string &filename, bool fortran_order, unsigned int n
 }
 
 template<typename Scalar>
-inline void
-LoadArrayFromNumpy(const std::string &filename, std::vector<unsigned long> &shape, std::vector <Scalar> &data) {
-  bool fortran_order;
-  LoadArrayFromNumpy<Scalar>(filename, shape, fortran_order, data);
-}
-
-template<typename Scalar>
 inline void LoadArrayFromNumpy(const std::string &filename, std::vector<unsigned long> &shape, bool &fortran_order,
                                std::vector <Scalar> &data) {
   std::ifstream stream(filename, std::ifstream::binary);
@@ -552,6 +545,13 @@ inline void LoadArrayFromNumpy(const std::string &filename, std::vector<unsigned
 
   // read the data
   stream.read(reinterpret_cast<char *>(data.data()), sizeof(Scalar) * size);
+}
+
+template<typename Scalar>
+inline void
+LoadArrayFromNumpy(const std::string &filename, std::vector<unsigned long> &shape, std::vector <Scalar> &data) {
+  bool fortran_order;
+  LoadArrayFromNumpy<Scalar>(filename, shape, fortran_order, data);
 }
 
 }  // namespace npy


### PR DESCRIPTION
LoadArrayFromNumpy(const std::string&, std::vector<unsigned long> &, std::vector <Scalar> &) was declared after LoadArrayFromNumpy(const std::string&, std::vector<unsigned long> &, bool &, std::vector <Scalar> &) and was using it.